### PR TITLE
fix(app): #3 clear user buffer on unmount of purchase registration page  

### DIFF
--- a/src/app/stores/customers/slices/customerCoreSlice.ts
+++ b/src/app/stores/customers/slices/customerCoreSlice.ts
@@ -9,7 +9,8 @@ export interface CustomerCoreSlice {
   customerPurchase: CustomerPurchase | null;
   isLoading: boolean;
   error: string | null;
-
+  
+  clearSelectedCustomer: () => void;
   setAllCustomers: (customers: Customer[]) => void;
   setFilteredCustomers: (customers: Customer[]) => void;
   setDisplayedCustomers: (customers: Customer[]) => void;
@@ -28,15 +29,16 @@ export const createCoreSlice: StateCreator<
 
   selectedCustomer: null,
   customerPurchase: null,
-
+  
   isLoading: false,
   error: null,
-
+  
   setAllCustomers: (customers) => set({ allCustomers: customers }),
   setFilteredCustomers: (customers) => set({ filteredCustomers: customers }),
   setDisplayedCustomers: (customers) => set({ displayedCustomers: customers }),
   setSelectedCustomer: (customer) => set({ selectedCustomer: customer }),
   setCustomerPurchase: (purchase) => set({ customerPurchase: purchase }),
   setIsLoading: (value) => set({ isLoading: value }),
-  setError: (message) => set({ error: message })
+  setError: (message) => set({ error: message }),
+  clearSelectedCustomer: () => set({ selectedCustomer: null })
 })

--- a/src/features/newPurchase/PurchasePage.tsx
+++ b/src/features/newPurchase/PurchasePage.tsx
@@ -23,9 +23,15 @@ import { useNavigate } from "react-router-dom"
 
 
 export const PurchasePage = () => {
-  const { activeTab, setActiveTab, selectedProducts, createPurchase, isLoading } = usePurchaseStore()
-  const { selectedCustomer, clearFilters, fetchCustomerPurchases, customerPurchase } = useCustomerStore()
+  const { activeTab, setActiveTab, selectedProducts, createPurchase, isLoading,  } = usePurchaseStore()
+  const { selectedCustomer, clearFilters, fetchCustomerPurchases, customerPurchase, clearSelectedCustomer } = useCustomerStore()
   const navigate = useNavigate()
+
+  useEffect(() => {
+    return () => {
+      clearSelectedCustomer()
+    }
+  }, [])
 
   const form = useForm<PurchaseFormValue>({
     resolver: zodResolver(purchaseSchema),


### PR DESCRIPTION
Added a cleanup effect to reset the selected customer from the global Zustand store when the PurchasePage component unmounts. This prevents stale data from persisting across navigation and ensures a fresh state when the page is revisited.